### PR TITLE
feat(友情链接): 添加 JEI-Web 友情链接

### DIFF
--- a/custom/info/friendLinks.json
+++ b/custom/info/friendLinks.json
@@ -192,8 +192,17 @@
         "primary": true,
         "regionality": "global",
         "localized_name": {
-          "zh_CN": "主页",
-          "en_US": "Home"
+          "zh_CN": "腾讯镜像",
+          "en_US": "Tencent Mirror"
+        },
+        "url": "https://fastjeiweb.sirrus.cc/"
+      },
+      {
+        "primary": false,
+        "regionality": "global",
+        "localized_name": {
+          "zh_CN": "Cloudflare 镜像",
+          "en_US": "Cloudflare Mirror"
         },
         "url": "https://jeiweb.sirrus.cc/"
       },


### PR DESCRIPTION
添加了 JEI-web 的友情链接。

<img width="128" height="auto" alt="" src="https://github.com/user-attachments/assets/321e5bcf-82aa-4398-873f-27fcf62d4c42" />

JEI-Web
一个为明日方舟:终末地和其他游戏提供的可扩展JEI类似物实现，支持物品浏览，配方查询，生产线规划，物品收藏，高级过滤，wiki查看，多资源包支持，历史记录和几个小游戏（这个还在做）
Solgan：万物一查即知    One Search, Everything Known
tags我不太清楚怎么写
目前只有海外部署https://jeiweb.sirrus.cc
英文直接ai翻译就行（