### PR TITLE
feat(友情链接): 添加协议终端的友情链接

### DIFF
--- a/custom/info/friendLinks.json
+++ b/custom/info/friendLinks.json
@@ -216,5 +216,36 @@
         "url": "https://github.com/AndreaFrederica/jei-web"
       }
     ]
+  },
+  {
+    "id": "协议终端",
+    "localized_name": {
+      "zh_CN": "协议终端",
+      "en_US": "Protocol Terminal"
+    },
+    "localized_description": {
+      "zh_CN": "《明日方舟：终末地》一站式玩家服务平台。深度集成数据查询、抽卡分析、百科检索与 MaaEnd，解决所有需求。",
+      "en_US": "An all-in-one service platform for Arknights: Endfield. Deeply integrating data queries, gacha analytics, wiki access, and MaaEnd to cover all your frontier needs."
+    },
+    "localized_slogan": {
+      "zh_CN": "一站式协议连接，全方位终末掌控",
+      "en_US": "One Terminal, Total Control"
+    },
+    "localized_tags": {
+      "zh_CN": ["一站式便携工具", "数据查询与分析"],
+      "en_US": ["All-in-One Tool", "Data & Analytics"]
+    },
+    "icon_url": "https://end.shallow.ink/icon.svg",
+    "links": [
+      {
+        "primary": true,
+        "regionality": "CHINA_MAINLAND",
+        "localized_name": {
+          "zh_CN": "进入终端",
+          "en_US": "Access Terminal"
+        },
+        "url": "https://end.shallow.ink"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
添加协议终端的友情链接
https://end.shallow.ink

```json
  {
    "id": "协议终端",
    "localized_name": {
      "zh_CN": "协议终端",
      "en_US": "Protocol Terminal"
    },
    "localized_description": {
      "zh_CN": "《明日方舟：终末地》一站式玩家服务平台。深度集成数据查询、抽卡分析、百科检索与 MaaEnd，解决所有需求。",
      "en_US": "An all-in-one service platform for Arknights: Endfield. Deeply integrating data queries, gacha analytics, wiki access, and MaaEnd to cover all your frontier needs."
    },
    "localized_slogan": {
      "zh_CN": "一站式协议连接，全方位终末掌控",
      "en_US": "One Terminal, Total Control"
    },
    "localized_tags": {
      "zh_CN": ["一站式便携工具", "数据查询与分析"],
      "en_US": ["All-in-One Tool", "Data & Analytics"]
    },
    "icon_url": "https://end.shallow.ink/icon.svg",
    "links": [
      {
        "primary": true,
        "regionality": "CHINA_MAINLAND",
        "localized_name": {
          "zh_CN": "进入终端",
          "en_US": "Access Terminal"
        },
        "url": "https://end.shallow.ink"
      }
    ]
  }
```

<img width="568" height="925" alt="image" src="https://github.com/user-attachments/assets/221dd32d-fd8b-4569-be09-aa0c533653fc" />
<img width="566" height="1038" alt="image" src="https://github.com/user-attachments/assets/489eef8f-6785-40d6-a8d3-c70fc58eeb96" />
</div>