### PR TITLE
feat(首页): 首页添加 AKEData 友链卡片

### DIFF
--- a/custom/core/homeCards.ts
+++ b/custom/core/homeCards.ts
@@ -584,6 +584,24 @@ export const homeCards: CardData[] = [
     ],
   },
   {
+    i18nKey: 'akedata',
+    icon: 'https://cos.yituliu.cn/endfield/icons/akedata.webp',
+    image: 'https://cos.yituliu.cn/endfield/icons/akedata.webp',
+    descriptionKey: 'description',
+    tagTypes: [CardTagType.ThirdParty],
+    buttons: [
+      {
+        i18nKey: 'buttons.main',
+        buttonType: ButtonType.Main,
+        action: ButtonActionType.Link,
+        actionData: 'https://www.akedata.top/',
+        target: true,
+        icon: 'mdi-web',
+        color: 'primary',
+      },
+    ],
+  },
+  {
     i18nKey: 'dige',
     icon: 'https://cos.yituliu.cn/endfield/icons/DIGEicon.png',
     image: 'https://cos.yituliu.cn/endfield/home/DIGE.png',

--- a/custom/info/friendLinks.json
+++ b/custom/info/friendLinks.json
@@ -225,5 +225,36 @@
         "url": "https://github.com/AndreaFrederica/jei-web"
       }
     ]
+  },
+  {
+    "id": "AKEData",
+    "localized_name": {
+      "zh_CN": "AKEData",
+      "en_US": "AKEData"
+    },
+    "localized_description": {
+      "zh_CN": "AKEData 是一个专为《明日方舟：终末地》玩家制作的数据查询网站。支持角色、武器、副本等各类数据查询",
+      "en_US": "AKEData is a data query website designed for Arknights: Endfield players. It supports queries for characters, weapons, dungeons, and other types of data."
+    },
+    "localized_slogan": {
+      "zh_CN": "AKEData - 《明日方舟：终末地》数据查询工具",
+      "en_US": "AKEData - Data Query Tool for Arknights: Endfield"
+    },
+    "localized_tags": {
+      "zh_CN": ["Wiki"],
+      "en_US": ["Wiki"]
+    },
+    "icon_url": "https://cos.yituliu.cn/endfield/icons/akedata.webp",
+    "links": [
+      {
+        "primary": true,
+        "regionality": "global",
+        "localized_name": {
+          "zh_CN": "主页",
+          "en_US": "Home"
+        },
+        "url": "https://www.akedata.top/"
+      }
+    ]
   }
 ]

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -177,6 +177,11 @@
           "linkIcon": "mdi-toolbox",
           "description": "Includes practical tools like gacha calculator, essence planner and gacha analysis"
         },
+        "akedata": {
+          "title": "AKEData",
+          "tag": "Third Party",
+          "description": "A data query website designed for Arknights: Endfield players. It supports queries for characters, weapons, dungeons, and other types of data."
+        },
         "dige": {
           "title": "D.I.G.E. - Thermal Energy Pond Planner",
           "tag": "Third Party",

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -177,6 +177,11 @@
           "linkIcon": "mdi-toolbox",
           "description": "包含攒抽计算器、基质规划器和抽卡分析等实用工具"
         },
+        "akedata": {
+          "title": "AKEData",
+          "tag": "第三方",
+          "description": "专为《明日方舟：终末地》玩家制作的数据查询网站。支持角色、武器、副本等各类数据查询"
+        },
         "dige": {
           "title": "D.I.G.E. - 终末地热能池规划器",
           "tag": "第三方",


### PR DESCRIPTION
根据 friendLinks.json 中新增的 AKEData 条目，在首页添加对应的第三方友链卡片。

**改动内容：**
- \custom/core/homeCards.ts\ — 新增 AKEData 首页卡片配置（ThirdParty 类型，链接到 https://www.akedata.top/）
- \i18n/locales/zh-CN.json\ — 新增中文 i18n 条目
- \i18n/locales/en-US.json\ — 新增英文 i18n 条目