### PR TITLE
feat: 理智药价值从解包数据自动注入

### DIFF
--- a/custom/core/apItems.json
+++ b/custom/core/apItems.json
@@ -1,0 +1,74 @@
+{
+  "item_ap_supply_lt": {
+    "apRecoverValue": 60,
+    "id": "item_ap_supply_lt"
+  },
+  "item_ap_supply_lt_l": {
+    "apRecoverValue": 100,
+    "id": "item_ap_supply_lt_l"
+  },
+  "item_ap_supply_lt_n": {
+    "apRecoverValue": 40,
+    "id": "item_ap_supply_lt_n"
+  },
+  "item_ap_supply_lt_s": {
+    "apRecoverValue": 10,
+    "id": "item_ap_supply_lt_s"
+  },
+  "item_ap_supply_nlt": {
+    "apRecoverValue": 40,
+    "id": "item_ap_supply_nlt"
+  },
+  "item_ap_supply_springfes_1": {
+    "apRecoverValue": 40,
+    "id": "item_ap_supply_springfes_1"
+  },
+  "item_ap_supply_springfes_2": {
+    "apRecoverValue": 40,
+    "id": "item_ap_supply_springfes_2"
+  },
+  "item_ap_supply_springfes_3": {
+    "apRecoverValue": 40,
+    "id": "item_ap_supply_springfes_3"
+  },
+  "item_ap_supply_universe": {
+    "apRecoverValue": 40,
+    "id": "item_ap_supply_universe"
+  },
+  "item_ap_take_out": {
+    "apRecoverValue": 120,
+    "id": "item_ap_take_out"
+  },
+  "item_char_ap_supply_aglina": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_aglina"
+  },
+  "item_char_ap_supply_camille": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_camille"
+  },
+  "item_char_ap_supply_laevat": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_laevat"
+  },
+  "item_char_ap_supply_mifu": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_mifu"
+  },
+  "item_char_ap_supply_tangtang": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_tangtang"
+  },
+  "item_char_ap_supply_wulfa": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_wulfa"
+  },
+  "item_char_ap_supply_yvonne": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_yvonne"
+  },
+  "item_char_ap_supply_zhuangfy": {
+    "apRecoverValue": 40,
+    "id": "item_char_ap_supply_zhuangfy"
+  }
+}

--- a/custom/core/itemValue.ts
+++ b/custom/core/itemValue.ts
@@ -1,8 +1,18 @@
 import type { ItemValueMap } from '@/shared/types/itemValue';
+import rawApItems from '@/custom/core/apItems.json';
 
 // 本文件的 itemName 字段仅作为备注使用，请勿依赖其值进行逻辑处理
 
 export const itemValueMap: ItemValueMap = {
+  // 从 apItems.json 注入理智药价值
+  ...Object.fromEntries(
+    Object.entries(rawApItems).map(([key, item]) => [
+      key,
+      { itemId: item.id, value: item.apRecoverValue },
+    ]),
+  ),
+
+  // 氪金资源
   item_originium_recharge: {
     itemId: 'item_originium_recharge',
     itemName: '衍质源石',
@@ -187,38 +197,6 @@ export const itemValueMap: ItemValueMap = {
     itemId: 'ticketgacha_special_ten_lt_1_0_1',
     itemName: '行火留烬十连凭证',
     value: (40 / 75) * 500 * 10,
-  },
-
-  // 理智物品
-  item_ap_supply_lt_n: {
-    itemId: 'item_ap_supply_lt_n',
-    itemName: '应急理智加强剂',
-    value: 40,
-  },
-  ap_supply_lt_n: {
-    itemId: 'ap_supply_lt_n',
-    itemName: '应急理智加强剂',
-    value: 40,
-  },
-  item_char_ap_supply_laevat: {
-    itemId: 'item_char_ap_supply_laevat',
-    itemName: '海盐冰淇淋',
-    value: 40,
-  },
-  item_char_ap_supply_yvonne: {
-    itemId: 'item_char_ap_supply_yvonne',
-    itemName: '草莓可丽饼',
-    value: 40,
-  },
-  item_char_ap_supply_aglina: {
-    itemId: 'item_char_ap_supply_aglina',
-    itemName: '栗花蜜',
-    value: 40,
-  },
-  item_char_ap_supply_zhuangfy: {
-    itemId: 'item_char_ap_supply_zhuangfy',
-    itemName: '油焖整笋罐头',
-    value: 40,
   },
 
   // 物资箱

--- a/scripts/gameData.ts
+++ b/scripts/gameData.ts
@@ -16,6 +16,7 @@ import type {
   ItemTable,
   ItemTypeTable,
   LevelLoadingTable,
+  RecoverApItemTable,
   RewardTable,
   SimulationTrainingCardPoolTable,
   SimulationTrainingCardTable,
@@ -165,6 +166,9 @@ export const itemTable: ItemTable = readJSONWithBigInt('TableCfg/ItemTable.json'
 export const itemTypeTable: ItemTypeTable = readJSONWithBigInt('TableCfg/ItemTypeTable.json');
 export const levelLoadingTable: LevelLoadingTable = readJSONWithBigInt(
   'TableCfg/LevelLoadingTable.json',
+);
+export const recoverApItemTable: RecoverApItemTable = readJSONWithBigInt(
+  'TableCfg/RecoverApItemTable.json',
 );
 export const rewardTable: RewardTable = readJSONWithBigInt('TableCfg/RewardTable.json');
 export const simulationTrainingCardPoolTable: SimulationTrainingCardPoolTable = readJSONWithBigInt(

--- a/scripts/makeAllData.ts
+++ b/scripts/makeAllData.ts
@@ -6,6 +6,7 @@
 import fs from 'node:fs';
 import { makeItems } from './tasks/makeItems';
 import { makePackGroups, makePacks, makePackShops } from './tasks/makePacks';
+import { makeRecoverApItems } from './tasks/makeRecoverApItems';
 import { makeTrialOfSwordmancyLevelTable } from './tasks/makeTrialOfSwordmancyLevelTable';
 import { makeTrialOfSwordmancyPools } from './tasks/makeTrialOfSwordmancyPools';
 import { makeEnergyAlluviums, makeWeapons } from './tasks/makeWeapons';
@@ -43,6 +44,10 @@ fs.writeFileSync('custom/core/packGroups.json', JSON.stringify(packGroups, null,
 console.log(`✓ custom/core/packs.json (${Object.keys(packs).length} packs)`);
 console.log(`✓ custom/core/packShops.json (${Object.keys(packShops).length} shops)`);
 console.log(`✓ custom/core/packGroups.json (${Object.keys(packGroups).length} groups)`);
+
+// ---------- recover-ap-items ----------
+fs.writeFileSync('custom/core/apItems.json', JSON.stringify(makeRecoverApItems(), null, 2), 'utf8');
+console.log(`✓ custom/core/apItems.json`);
 
 // ---------- trial-of-swordmancy level table ----------
 const trialOfSwordmancyLevelTable = makeTrialOfSwordmancyLevelTable();

--- a/scripts/models/index.ts
+++ b/scripts/models/index.ts
@@ -27,6 +27,7 @@ export type { ItemListByType, ItemListByTypeTable } from './itemListByTypeTable'
 export type { Item, ItemTable } from './itemTable';
 export type { ItemType, ItemTypeTable } from './itemTypeTable';
 export type { LevelLoading, LevelLoadingTable } from './levelLoadingTable';
+export type { RecoverApItem, RecoverApItemTable } from './recoverApItemTable';
 export type { ItemBundle, Reward, RewardTable } from './rewardTable';
 export type {
   SimulationTrainingCard,

--- a/scripts/models/recoverApItemTable.ts
+++ b/scripts/models/recoverApItemTable.ts
@@ -1,0 +1,8 @@
+/** 单个恢复 AP 道具 */
+export interface RecoverApItem {
+  apRecoverValue: number;
+  id: string;
+}
+
+/** RecoverApItemTable.json 对应整个表 */
+export type RecoverApItemTable = Record<string, RecoverApItem>;

--- a/scripts/tasks/makeRecoverApItems.ts
+++ b/scripts/tasks/makeRecoverApItems.ts
@@ -1,0 +1,15 @@
+import type { RecoverApItem } from '../models';
+import { recoverApItemTable } from '../gameData';
+
+/**
+ * 生成恢复 AP 道具数据
+ * 将解包数据按原样输出到一图流使用的 JSON 中
+ */
+export function makeRecoverApItems(): Record<string, RecoverApItem> {
+  // 按字典序排序键，保证 diff 最小
+  return Object.fromEntries(
+    Object.keys(recoverApItemTable)
+      .toSorted()
+      .map((key) => [key, recoverApItemTable[key]!]),
+  );
+}


### PR DESCRIPTION
## 变更内容

### 1. 新增理智物品数据脚本
- 创建 `scripts/models/recoverApItemTable.ts` — 解包 `RecoverApItemTable.json` 的 model
- 创建 `scripts/tasks/makeRecoverApItems.ts` — task 生成 `custom/core/apItems.json`
- 在 `scripts/gameData.ts` 和 `scripts/models/index.ts` 中注册
- 在 `scripts/makeAllData.ts` 中接入构建流程

### 2. 理智药价值数据源切换
- `custom/core/itemValue.ts`：删除硬编码的 6 个理智药条目，改为从 `apItems.json` 自动注入
- `shared/utils/gameData/item.ts`：`getItemValue` 回退到 `itemValueMap` 即可，无需单独处理理智药

### 3. 规范补充
- 新增 `.github/skills/scripts-convention/SKILL.md` — scripts 编码规范 skill
- `scripts/gameData.ts` 中数据加载按字典序排序