### PR TITLE
fix(ItemIcon): 修复部分武器和道具缺少图标时显示异常的问题

### DIFF
--- a/app/components/container/ItemIcon.vue
+++ b/app/components/container/ItemIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="itemIconPlaceholderRef" class="item-icon-placeholder">
-    <img :alt="itemName" class="item-icon-img" :src="getItemIconUrl(props.itemId)" />
+    <img :alt="itemName" class="item-icon-img" :src="itemIconUrl" />
     <div class="item-gradient-overlay" />
     <div class="item-tier-bar" />
     <div v-if="props.showItemName" ref="itemNameRef" class="item-name">
@@ -38,6 +38,15 @@ const itemName = computed(() => {
     return props.itemName;
   } else {
     return getItemName(props.itemId, locale.value);
+  }
+});
+
+const itemIconUrl = computed(() => {
+  const itemIconUrl = getItemIconUrl(props.itemId);
+  if (!itemIconUrl) {
+    return 'https://cos.yituliu.cn/endfield/other/默认武器图标.webp';
+  } else {
+    return itemIconUrl;
   }
 });
 

--- a/custom/core/items.json
+++ b/custom/core/items.json
@@ -33653,7 +33653,7 @@
       "zh-CN": "武器",
       "en-US": "Weapon"
     },
-    "iconId": "wpn_funnel_sierzhen"
+    "iconId": null
   },
   "联结点": {
     "id": "联结点",
@@ -33667,7 +33667,7 @@
       "zh-CN": "武器",
       "en-US": "Weapon"
     },
-    "iconId": "wpn_funnel_lianjiedian"
+    "iconId": null
   },
   "曜夜的首演": {
     "id": "曜夜的首演",
@@ -33681,7 +33681,7 @@
       "zh-CN": "武器",
       "en-US": "Weapon"
     },
-    "iconId": "wpn_lance_yaoyeshouyan"
+    "iconId": null
   },
   "黄金时代": {
     "id": "黄金时代",
@@ -33695,35 +33695,7 @@
       "zh-CN": "武器",
       "en-US": "Weapon"
     },
-    "iconId": "wpn_lance_huangjinshidai"
-  },
-  "贴纸·抑制器": {
-    "id": "贴纸·抑制器",
-    "name": {
-      "zh-CN": "贴纸·抑制器",
-      "en-US": "Sticker: Suppressor"
-    },
-    "rarity": 5,
-    "type": 70,
-    "typeName": {
-      "zh-CN": "拍照贴纸",
-      "en-US": "Photograph Sticker"
-    },
-    "iconId": "item_shot_sticker_activity_5"
-  },
-  "头像·游乐团团": {
-    "id": "头像·游乐团团",
-    "name": {
-      "zh-CN": "头像·游乐团团",
-      "en-US": "Portrait: Fun Group"
-    },
-    "rarity": 5,
-    "type": 66,
-    "typeName": {
-      "zh-CN": "头像",
-      "en-US": "Portrait"
-    },
-    "iconId": "item_user_avatar_activity_8"
+    "iconId": null
   },
   "遥望": {
     "id": "遥望",
@@ -33737,6 +33709,34 @@
       "zh-CN": "武器",
       "en-US": "Weapon"
     },
-    "iconId": "wpn_sword_0023"
+    "iconId": null
+  },
+  "贴纸·抑制器": {
+    "id": "贴纸·抑制器",
+    "name": {
+      "zh-CN": "贴纸·抑制器",
+      "en-US": "Sticker: Suppressor"
+    },
+    "rarity": 5,
+    "type": 70,
+    "typeName": {
+      "zh-CN": "拍照贴纸",
+      "en-US": "Photograph Sticker"
+    },
+    "iconId": null
+  },
+  "头像·游乐团团": {
+    "id": "头像·游乐团团",
+    "name": {
+      "zh-CN": "头像·游乐团团",
+      "en-US": "Portrait: Fun Group"
+    },
+    "rarity": 5,
+    "type": 66,
+    "typeName": {
+      "zh-CN": "头像",
+      "en-US": "Portrait"
+    },
+    "iconId": null
   }
 }

--- a/custom/core/items.ts
+++ b/custom/core/items.ts
@@ -6,7 +6,7 @@ export interface Item {
   rarity: number;
   type: number;
   typeName: Record<string, string>;
-  iconId: string;
+  iconId: string | null;
 }
 
 export const items: Record<string, Item> = rawItems;

--- a/shared/utils/gameData/item.ts
+++ b/shared/utils/gameData/item.ts
@@ -42,7 +42,7 @@ export function getCharAvatarUrl(charId: string): string {
 
 export function getItemIconUrl(itemId: string): string | undefined {
   const iconId = items[itemId]?.iconId;
-  if (iconId === undefined) {
+  if (!iconId) {
     return undefined;
   }
   return `https://cos.yituliu.cn/endfield/endfielddata/assets/beyond/dynamicassets/gameplay/ui/sprites/itemicon/${iconId}.webp`;


### PR DESCRIPTION
- 将 iconId 类型改为 string | null，支持显式标记无图标
- ItemIcon.vue 新增回退逻辑，无图标时显示默认武器图标
- 更新 items.json，将无独立图标的武器/贴纸等 iconId 设为 null
- 新增武器「遥望」数据
