### PR TITLE
feat(攒抽计算器): 增加活动时间同步与信用商店奖励

### DIFF
--- a/app/pages/tools/gacha-calculator.vue
+++ b/app/pages/tools/gacha-calculator.vue
@@ -7,6 +7,7 @@ import type {
   RewardStatisticsResultDetail,
   TotalPullsSingle,
 } from '@/shared/types/gacha-calculator';
+import { dateFormat } from '#shared/utils/dateUtil';
 import {
   addReward,
   calculateDaysDifference,
@@ -24,6 +25,7 @@ import { activityReward } from '@/custom/core/gacha/activityReward';
 // 奖励引入
 import {
   calculatorDailyReward,
+  creditShopReward,
   dailyAllRewardTable,
   dailyReward,
   poolStartDate,
@@ -135,6 +137,7 @@ const devDebugGreenBackground = ref(false);
 const devDebugHideCardShadow = ref(false);
 const devDebugHideWarning = ref(false);
 const devDebugHideProbability = ref(false);
+const devShowActivityTimeRange = ref(false);
 const isDevScreenshotCapturing = ref(false);
 const devScreenshotStatus = ref('');
 const GACHA_CALCULATOR_SCREENSHOT_SCALE = 4;
@@ -201,6 +204,34 @@ function startDateDebug() {
 
   poolStartDate.value = newDate;
   calc();
+}
+
+function getActivityGachaRewardEnd(reward: Reward) {
+  const start = new Date(reward.start);
+  const rewardDays = reward.gachaRewardDays ?? 1;
+
+  return new Date(start.getTime() + rewardDays * 24 * 60 * 60 * 1000);
+}
+
+function getActivityTimeRangeText(reward: Reward) {
+  const rewardDays = reward.gachaRewardDays ?? 1;
+  const activityType = rewardDays === 1 ? '瞬时' : '持续';
+
+  return `活动：${dateFormat(reward.start, 'yyyy/MM/dd HH:mm')} - ${dateFormat(
+    reward.end,
+    'yyyy/MM/dd HH:mm',
+  )} · ${activityType} · 抽卡资源前 ${rewardDays} 天`;
+}
+
+function syncActivityRewardsByTime() {
+  const syncDate = new Date(devStartDate.value);
+  syncDate.setHours(12, 0, 0, 0);
+
+  for (const reward of activityReward.value) {
+    reward.active = syncDate < getActivityGachaRewardEnd(reward);
+  }
+
+  setDevScreenshotStatus(`已按 ${dateFormat(syncDate, 'yyyy/MM/dd HH:mm')} 同步活动奖励`);
 }
 
 function clearDevScreenshotStatusTimer() {
@@ -724,6 +755,7 @@ function dailyRewardStatistics(): void {
   };
 
   addReward(result, dailyReward.value);
+  addReward(result, creditShopReward.value);
   addReward(result, weekTaskReward.value);
 
   // 日常奖励重构
@@ -1658,8 +1690,6 @@ const arsenalCreditShopQuota = computed(
   () => arsenalCalculationDays.value * ARSENAL_DAILY_CREDIT_QUOTA,
 );
 
-const arsenalRoutineQuota = computed(() => arsenalWeeklyQuota.value + arsenalCreditShopQuota.value);
-
 const arsenalRechargeQuota = computed(() => {
   let quota = 0;
 
@@ -1683,7 +1713,8 @@ const arsenalRechargeQuota = computed(() => {
 const arsenalQuotaResult = computed(
   () =>
     arsenalPullQuota.value +
-    arsenalRoutineQuota.value +
+    arsenalWeeklyQuota.value +
+    arsenalCreditShopQuota.value +
     arsenalRechargeQuota.value +
     arsenalOriginiumQuota.value +
     arsenalExistingQuota.value,
@@ -2332,9 +2363,23 @@ function toggleStringInArray(str: string, arr: string[]): string[] {
                 </div>
                 <div class="gacha-calculator-arsenal-breakdown-row">
                   <div>
-                    <strong>周常与信用商店（估算）</strong>
+                    <strong>周常</strong>
                     <span>
-                      {{ arsenalWeeklyCount }} 周 × {{ ARSENAL_WEEKLY_QUOTA }} +
+                      {{ arsenalWeeklyCount }} 周 × {{ ARSENAL_WEEKLY_QUOTA }}
+                    </span>
+                  </div>
+                  <div class="gacha-calculator-arsenal-breakdown-value">
+                    <img
+                      alt="武库配额"
+                      src="https://cos.yituliu.cn/endfield/endfielddata/assets/beyond/dynamicassets/gameplay/ui/sprites/walleticon/item_gachabyproducts_weapongold.png"
+                    />
+                    <strong>{{ arsenalWeeklyQuota }}</strong>
+                  </div>
+                </div>
+                <div class="gacha-calculator-arsenal-breakdown-row">
+                  <div>
+                    <strong>信用商店（估算）</strong>
+                    <span>
                       {{ arsenalCalculationDays }} 天 × {{ ARSENAL_DAILY_CREDIT_QUOTA }}
                     </span>
                   </div>
@@ -2343,7 +2388,7 @@ function toggleStringInArray(str: string, arr: string[]): string[] {
                       alt="武库配额"
                       src="https://cos.yituliu.cn/endfield/endfielddata/assets/beyond/dynamicassets/gameplay/ui/sprites/walleticon/item_gachabyproducts_weapongold.png"
                     />
-                    <strong>{{ arsenalRoutineQuota }}</strong>
+                    <strong>{{ arsenalCreditShopQuota }}</strong>
                   </div>
                 </div>
                 <div class="gacha-calculator-arsenal-breakdown-row">
@@ -2566,7 +2611,24 @@ function toggleStringInArray(str: string, arr: string[]): string[] {
                   hide-details
                   label="隐藏概率提示"
                 />
+                <v-switch
+                  v-model="devShowActivityTimeRange"
+                  color="primary"
+                  density="compact"
+                  hide-details
+                  label="显示活动时间"
+                />
               </div>
+
+              <v-btn
+                color="primary"
+                prepend-icon="mdi-clock-sync-outline"
+                size="small"
+                variant="tonal"
+                @click="syncActivityRewardsByTime"
+              >
+                时间同步
+              </v-btn>
 
               <h3>截图调试</h3>
               <div class="gacha-calculator-debug-screenshot-actions">
@@ -2746,14 +2808,15 @@ function toggleStringInArray(str: string, arr: string[]): string[] {
 
           <v-expansion-panel-text>
             <div @click="triggerDevModeByDailyReward">
-              <GachaCalculatorResourceSingle
-                v-bind="dailyReward"
-                :weapon-quota="arsenalCreditShopQuota"
-              />
+              <GachaCalculatorResourceSingle v-bind="dailyReward" />
             </div>
             <GachaCalculatorResourceSingle
               v-bind="weekTaskReward"
               :weapon-quota="arsenalWeeklyQuota"
+            />
+            <GachaCalculatorResourceSingle
+              v-bind="creditShopReward"
+              :weapon-quota="arsenalCreditShopQuota"
             />
 
             <v-divider style="margin: 1rem 0" />
@@ -2781,13 +2844,22 @@ function toggleStringInArray(str: string, arr: string[]): string[] {
           </v-expansion-panel-title>
 
           <v-expansion-panel-text>
-            <GachaCalculatorResourceSingleBtn
+            <div
               v-for="item in activityReward"
               v-show="shouldDisplayAndCount(item)"
               :key="item.id"
-              :reward="item"
-              @click="item.active = !item.active"
-            />
+            >
+              <GachaCalculatorResourceSingleBtn
+                :reward="item"
+                @click="item.active = !item.active"
+              />
+              <div
+                v-if="currentMode === 'dev' && devShowActivityTimeRange"
+                class="gacha-calculator-activity-time-range"
+              >
+                {{ getActivityTimeRangeText(item) }}
+              </div>
+            </div>
           </v-expansion-panel-text>
         </v-expansion-panel>
         <!--常驻奖励重构-->
@@ -2994,6 +3066,12 @@ function toggleStringInArray(str: string, arr: string[]): string[] {
 
 .gacha-calculator-debug-screenshot-status {
   margin-top: 4px;
+}
+
+.gacha-calculator-activity-time-range {
+  margin: -2px 4px 6px;
+  color: rgba(var(--v-theme-on-surface), 0.55);
+  font-size: 0.7rem;
 }
 
 .gacha-calculator-card-title {

--- a/custom/core/gacha/activityReward.ts
+++ b/custom/core/gacha/activityReward.ts
@@ -8,12 +8,25 @@ import PoolInfoTable from '@/custom/core/gacha/data/pool_info_table.json';
 import sklandSignInTable from '@/custom/core/gacha/data/skland_sign_in_table.json';
 
 const currentVersion = '寻遗散记';
+const DEFAULT_ACTIVITY_GACHA_REWARD_DAYS = 1;
+const activityGachaRewardDayOverrides: Record<string, number> = {
+  宏运连连乐: 15,
+  根脉奇境: 7,
+  '炽燃·竞技大会': 7,
+  '丰碑留名·兽吼': 7,
+};
 
 const activityReward = ref<Reward[]>([]);
+
+function applyGachaRewardDays(reward: Reward) {
+  reward.gachaRewardDays =
+    activityGachaRewardDayOverrides[reward.id] ?? DEFAULT_ACTIVITY_GACHA_REWARD_DAYS;
+}
 
 for (const reward of ActivityRewardTable as Reward[]) {
   reward.start = new Date(reward.start);
   reward.end = new Date(reward.end);
+  applyGachaRewardDays(reward);
 
   reward.active = currentVersion === reward.version;
   if (reward.start.getTime() < Date.now()) {
@@ -26,6 +39,7 @@ for (const reward of ActivityRewardTable as Reward[]) {
 for (const reward of OtherRewardTableJson as Reward[]) {
   reward.start = new Date(reward.start);
   reward.end = new Date(reward.end);
+  applyGachaRewardDays(reward);
   reward.active = currentVersion === reward.version;
   if (reward.start.getTime() < Date.now()) {
     reward.active = false;
@@ -36,6 +50,7 @@ for (const reward of OtherRewardTableJson as Reward[]) {
 for (const reward of sklandSignInTable as Reward[]) {
   reward.start = new Date(reward.start);
   reward.end = new Date(reward.end);
+  applyGachaRewardDays(reward);
   reward.active = currentVersion === reward.version;
   if (reward.start.getTime() < Date.now()) {
     reward.active = false;
@@ -65,6 +80,7 @@ function createNewPoolActivity() {
         },
         start: startDate,
         end: new Date(item.versionEnd),
+        gachaRewardDays: DEFAULT_ACTIVITY_GACHA_REWARD_DAYS,
         type: '通用',
         module: '活动',
         active: currentVersion === item.version,
@@ -88,6 +104,7 @@ function createNewPoolActivity() {
       },
       start: new Date(item.poolStart),
       end: new Date(item.poolEnd),
+      gachaRewardDays: 3,
       type: item.character,
       module: '活动',
       active: currentVersion === item.version,

--- a/custom/core/gacha/dailyReward.ts
+++ b/custom/core/gacha/dailyReward.ts
@@ -70,6 +70,27 @@ const dailyReward = ref<Reward>({
   },
 });
 
+const creditShopReward = ref<Reward>({
+  id: 'credit_shop_reward',
+  name: {
+    zh: `信用商店（估算）× 0 天`,
+    en: '',
+  },
+  start: new Date('2026/01/22 12:00:00'),
+  end: new Date('2099/12/31 12:00:00'),
+  type: '通用',
+  module: '日常',
+  active: true,
+  version: '基础资源',
+  content: {
+    originiumRecharge: 0,
+    diamond: 0,
+    ticketgachaStandardSingle: 0,
+    ticketgachaSpecialSingle: 0,
+    ticketgachaLimitedSingle: 0,
+  },
+});
+
 const weekTaskReward = ref<Reward>({
   id: 'week_task_reward',
   name: {
@@ -98,6 +119,12 @@ function calculatorDailyReward(start: Date, end: Date): void {
     en: '',
   };
   dailyReward.value.content.diamond = numberRound(remainingDays, 0) * 200;
+
+  creditShopReward.value.name = {
+    zh: `信用商店（估算）× ${numberRound(remainingDays, 0)} 天`,
+    en: '',
+  };
+  creditShopReward.value.content.diamond = numberRound(remainingDays, 0) * 25;
 
   const remainingWeek: number = countTuesdaysBetweenV2(start, end);
   weekTaskReward.value.name = {
@@ -146,6 +173,26 @@ function createVersionDailyReward(start: Date, end: Date, version: string): Rewa
       content: {
         originiumRecharge: 0,
         diamond: numberRound(remainingWeek, 0) * 500,
+        ticketgachaStandardSingle: 0,
+        ticketgachaSpecialSingle: 0,
+        ticketgachaLimitedSingle: 0,
+      },
+    },
+    {
+      id: 'credit_shop_reward',
+      name: {
+        zh: `信用商店（估算）× ${numberRound(remainingDays, 0)} 天`,
+        en: '',
+      },
+      start: new Date('2026/01/22 12:00:00'),
+      end: new Date('2099/12/31 12:00:00'),
+      type: '通用',
+      module: '日常',
+      active: true,
+      version,
+      content: {
+        originiumRecharge: 0,
+        diamond: numberRound(remainingDays, 0) * 25,
         ticketgachaStandardSingle: 0,
         ticketgachaSpecialSingle: 0,
         ticketgachaLimitedSingle: 0,
@@ -239,6 +286,7 @@ for (const poolInfo of PoolInfoTable) {
 export {
   calculatorDailyReward,
   createVersionDailyReward,
+  creditShopReward,
   dailyAllRewardTable,
   dailyReward,
   poolStartDate,

--- a/shared/types/gacha-calculator.ts
+++ b/shared/types/gacha-calculator.ts
@@ -75,6 +75,7 @@ export interface Reward {
   };
   start: string | Date;
   end: string | Date;
+  gachaRewardDays?: number;
   type: string;
   module: string;
   regional?: string;


### PR DESCRIPTION
## 修改内容
- 将信用商店（估算）拆为独立日常奖励，按天计入 25 合成玉和 10 武库配额。
- 在开发模式增加活动时间同步与活动时间显示，支持按抽卡资源有效天数同步活动选中状态。
- 为当前活动奖励配置默认 1 天、卡池签到 3 天及已确认的活动例外天数。

## 验证
- `yarn eslint app/pages/tools/gacha-calculator.vue custom/core/gacha/activityReward.ts shared/types/gacha-calculator.ts`
- `git diff --check`